### PR TITLE
remove useless lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,8 @@ LUCI_DEPENDS:=+iputils-arping +curl
 LUCI_PKGARCH:=all
 PKG_NAME:=luci-app-serverchan
 PKG_VERSION:=1.0
-PKG_RELEASE:=40
+PKG_RELEASE:=42
 
 include $(TOPDIR)/feeds/luci/luci.mk
 
-define Package/$(PKG_NAME)/postinst
-#!/bin/sh
-chmod 0755 /etc/init.d/serverchan
-chmod 0755 /usr/bin/serverchan/serverchan
-/etc/init.d/serverchan enable >/dev/null 2>&1
-exit 0
-endef
-
 # call BuildPackage - OpenWrt buildroot signature
-

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@
 #### 已知BUG
 
 - 多拨环境下无法获取 wan ip，详情查看https://github.com/tty228/luci-app-serverchan/issues/8
-- 可能因为编译环境不同或者别的原因，makefile 提升权限失败，造成无法启动，对makefile没研究过，不太了解
-如遇到此问题请查阅 @zxlhhyccc 的解决方案
-https://github.com/tty228/luci-app-serverchan/issues/1
 - 由于不同设备温度文件不一样，如遇到设备温度无法正常读取，请修改
 “cut -c1-2 /sys/class/thermal/thermal_zone0/temp” @KFERMercer 
 


### PR DESCRIPTION
readme 文件中指出的权限问题并不存在. https://github.com/tty228/luci-app-serverchan/commit/1600292b05ff45f60b1cc18aae9e861da0824ff9 已经修复了此问题.

OpenWrt 对安装后的文件权限已有定义, 只需要修改对应文件本身的权限即可解决问题. OpenWrt 进行 compile 时会遵循原本权限掩码. 不需要在 Makefile 里重复造轮子.

如有遇到权限问题, 请执行`make clean`清空编译缓存后重试. 
