### PR TITLE
1、修复IPv6环境下，curl命令指定接口名来绑定接口操作失败的问题

### DIFF
--- a/root/usr/bin/serverchan/serverchan
+++ b/root/usr/bin/serverchan/serverchan
@@ -541,7 +541,7 @@ function send(){
 		if [ -z "$ipv6_interface" ] ; then send_wanIPv6=$(ip addr show|grep -v deprecated|grep -A1 'inet6 [^f:]'|sed -nr ':a;N;s#^ +inet6 ([a-f0-9:]+)/.+? scope global .*? valid_lft ([0-9]+sec) .*#\2 \1#p;ta'|sort -nr|head -n1|cut -d' ' -f2);fi
 		if [ ! -z "$ipv4_interface" ] ; then send_hostIP=$(curl -k -s -4 --interface $ipv4_interface $ipv4_URL);fi
 		if [ -z "$ipv4_interface" ] ; then send_hostIP=$(curl -k -s -4 $ipv4_URL);fi
-		if [ ! -z "$ipv6_interface" ] ; then send_hostIPv6=$(curl -k -s -6 --interface $ipv6_interface $ipv6_URL);fi
+		if [ ! -z "$ipv6_interface" ] ; then send_hostIPv6=$(curl -k -s -6 --interface $send_wanIPv6 $ipv6_URL);fi
 		if [ -z "$ipv6_interface" ] ; then send_hostIPv6=$(curl -k -s -6 $ipv6_URL);fi
 		if [ ! -z "$router_wan" ] && [ "$router_wan" -eq "1" ] ; then
 			send_content=${send_content}"%0D%0A%0D%0A""---%0D%0A%0D%0A#### WAN 口信息%0D%0A%0D%0A     ip：$send_wanIP"


### PR DESCRIPTION
关联问题：#44 
如果觉得修改不妥，可以拒绝，毕竟我也没在其他设备上测试过。