### PR TITLE
fix: fix decive offline testing failed on stones v2.7 k3 lede

### DIFF
--- a/root/usr/bin/serverchan/serverchan
+++ b/root/usr/bin/serverchan/serverchan
@@ -840,7 +840,7 @@ if [ "$1" ] ;then
 	local wlan_online=`iw dev $ip_interface station dump | grep -i -w $ip_mac | grep Station 2>/dev/null`
 	local ip_ms=`echo $( arping -I $( cat /proc/net/arp | grep -w $1 | awk  '{print $6}' | grep -v "^$" | sort -u ) -c 20 -f -w 2 $1)`
 	if [ -z "$wlan_online" ] && ( ! echo ${ip_ms} | grep -q ms );then
-		local ip_ms=`ping -c 5 -w 3 $1`
+		local ip_ms=`ping -c 5 -w 3 $1 | grep -v '100% packet loss'`
 		if ( ! echo ${ip_ms} | grep -q ms );then
 			enable_detection 1
 			local ip_ms=`echo $( arping -I $( cat /proc/net/arp | grep -w $1 | awk  '{print $6}' | grep -v "^$" | sort -u ) -c 20 -f -w $down_timeout $1)`


### PR DESCRIPTION
修复方式为：通过判断设备 100% 丢包来作为设备离线的一个辅助判断。

----
具体信息如下：

检测设备离线的函数中，有个 if 判断在我这个 k3 固件版本中无法命中：

```
local wlan_online=`iw dev $ip_interface station dump | grep -i -w $ip_mac | grep Station 2>/dev/null`
local ip_ms=`echo $( arping -I $( cat /proc/net/arp | grep -w $1 | awk  '{print $6}' | grep -v "^$" | sort -u ) -c 20 -f -w 2 $1)`
if [ -z "$wlan_online" ] && ( ! echo ${ip_ms} | grep -q ms );then
    local ip_ms=`ping -c 5 -w 3 $1` # 这一行
    if ( ! echo ${ip_ms} | grep -q ms );then
        enable_detection 1
        local ip_ms=`echo $( arping -I $( cat /proc/net/arp | grep -w $1 | awk  '{print $6}' | grep -v "^$" | sort -u ) -c 20 -f -w $down_timeout $1)`
    fi
fi
```

上面代码中这一行，最终 `ip_ms`  赋值为：

```
PING 10.0.0.202 (10.0.0.202) 56(84) bytes of data. --- 10.0.0.202 ping statistics --- 3 packets transmitted, 0 received, 100% packet loss, time 2067ms
```

可以看出，虽然设备已经离线，100% 丢包，但是还是有输出延迟信息 `time 2067ms`，导致在下一个 if 判断中：

```
if ( ! echo ${ip_ms} | grep -q 'ms' ); then
```

grep 成功，取反变为 false，无法进入该 if，也就是在这一步已经认为设备在线了，没有进行一次 arping 的设备离线超时检测，最终认为该设备在线。



Closed: https://github.com/tty228/luci-app-serverchan/issues/76
