### PR TITLE
升级server酱通知为server酱Turbo 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-serverchan
 PKG_VERSION:=1.80
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/root/usr/bin/serverchan/serverchan
+++ b/root/usr/bin/serverchan/serverchan
@@ -906,7 +906,7 @@ function send(){
 	local send_title=`echo "$send_title"|sed $'s/\ /%20/g'|sed $'s/\"/%22/g'|sed $'s/\#/%23/g'|sed $'s/\&/%26/g'|sed $'s/\,/%2C/g'|sed $'s/\//%2F/g'|sed $'s/\:/%3A/g'|sed $'s/\;/%3B/g'|sed $'s/\=/%3D/g'|sed $'s/\@/%40/g'`
 	[ -z "$send_content" ] && local send_content="${markdown_splitline}#### 我遇到了一个难题${markdown_linefeed}${markdown_tab}定时发送选项错误，你没有选择需要发送的项目，该怎么办呢${markdown_splitline}"
 	local nowtime=`date "+%Y-%m-%d %H:%M:%S"`
-	[ "$send_disturb" -eq "0" ] && [ -z "$send_tg" ] && curl -s "http://sc.ftqq.com/${sckey}.send?text=${send_title}" -d "&desp=${nowtime}${markdown_linefeed}${send_content}" >/dev/null 2>&1
+	[ "$send_disturb" -eq "0" ] && [ -z "$send_tg" ] && curl -s "https://sctapi.ftqq.com/${sckey}.send?text=${send_title}" -d "&desp=${nowtime}${markdown_linefeed}${send_content}" >/dev/null 2>&1
 	[ "$send_disturb" -eq "0" ] && [ ! -z "$send_tg" ] && [ "$send_tg" -eq "2" ] && curl -s "http://sctapi.ftqq.com/${sctkey}.send?text=${send_title}" -d "desp=${nowtime}${markdown_linefeed}${send_content}" >/dev/null 2>&1
 	[ "$send_disturb" -eq "0" ] && [ ! -z "$send_tg" ] && [ "$send_tg" -eq "1" ] && curl -d "text=${send_title}${markdown_linefeed}${nowtime}${markdown_linefeed}${send_content}" -X POST "${tgtoken}" >/dev/null 2>&1
 	deltemp
@@ -982,7 +982,7 @@ while [ "$serverchan_enable" -eq "1" ]; do
 		nowtime=`date "+%Y-%m-%d %H:%M:%S"`
 		[ ! -z "$device_name" ] && title="【$device_name】$title"
 		title=`echo "$title"|sed $'s/\ /%20/g'|sed $'s/\"/%22/g'|sed $'s/\#/%23/g'|sed $'s/\&/%26/g'|sed $'s/\,/%2C/g'|sed $'s/\//%2F/g'|sed $'s/\:/%3A/g'|sed $'s/\;/%3B/g'|sed $'s/\=/%3D/g'|sed $'s/\@/%40/g'`
-		[ "$disturb" -eq "0" ] && [ -z "$send_tg" ] && curl -s "http://sc.ftqq.com/${sckey}.send?text=${title}" -d "desp=${nowtime}${markdown_linefeed}${content}" >/dev/null 2>&1
+		[ "$disturb" -eq "0" ] && [ -z "$send_tg" ] && curl -s "https://sctapi.ftqq.com/${sckey}.send?text=${title}" -d "desp=${nowtime}${markdown_linefeed}${content}" >/dev/null 2>&1
 		[ "$disturb" -eq "0" ] && [ ! -z "$send_tg" ] && [ "$send_tg" -eq "2" ] && curl -s "http://sctapi.ftqq.com/${sctkey}.send?text=${title}" -d "desp=${nowtime}${markdown_linefeed}${content}" >/dev/null 2>&1
 		[ "$disturb" -eq "0" ] && [ ! -z "$send_tg" ] && [ "$send_tg" -eq "1" ] && curl -d "text=${title}${markdown_linefeed}${nowtime}${markdown_linefeed}${content}" -X POST "${tgtoken}" >/dev/null 2>&1
 	fi


### PR DESCRIPTION
旧版[server酱](http://sc.ftqq.com/9.version)通知方式将在4月底下线，之后升级为[server酱Turbo](https://sct.ftqq.com/)，详细方式参见[SendKey获取](https://sct.ftqq.com/sendkey)