### PR TITLE
feat: 增加企业微信直推功能

### DIFF
--- a/luasrc/model/cbi/serverchan/setting.lua
+++ b/luasrc/model/cbi/serverchan/setting.lua
@@ -30,6 +30,9 @@ a.rmempty = true
 a=s:taboption("basic", Value,"sckey",translate('微信推送/新旧共用'), translate("").."旧版调用代码<a href='http://sc.ftqq.com' target='_blank'>点击这里</a><br>新版代码获取<a href='https://sct.ftqq.com/' target='_blank'>点击这里</a><br>")
 a.rmempty = true
 
+a=s:taboption("basic", Value,"qywx_token",translate('企业微信凭证'), translate("").."格式必须为：corpid;userid;agentid;corpsecret，获取说明<a href='https://work.weixin.qq.com/api/doc/10013' target='_blank'>点击这里</a><br>注意：使用企业微信推送会导致其他推送的内容排版错乱")
+a.rmempty = true
+
 a=s:taboption("basic",Value,"pushplus_token",translate('pushplus_token'),translate("").."获取pushplus_token <a href='http://www.pushplus.plus/' target='_blank'>点击这里</a><br>")
 a.rmempty = true
 

--- a/root/usr/bin/serverchan/serverchan
+++ b/root/usr/bin/serverchan/serverchan
@@ -10,7 +10,7 @@ function get_config(){
 
 # 初始化设置信息
 function read_config(){
-	get_config "serverchan_enable" "sckey" "sctkey" "tg_token" "chat_id" "pushplus_token" "serverchan_ipv4" "ipv4_interface" "ipv4_URL" "serverchan_ipv6" "ipv6_interface" "ipv6_URL" "serverchan_up" "serverchan_down" "serverchan_sheep" "serverchan_whitelist" "serverchan_blacklist" "serverchan_interface" "starttime" "endtime" "cpuload_enable" "cpuload" "temperature_enable" "temperature" "device_name" "err_enable" "network_err_event" "err_sheep_enable" "system_time_event" "autoreboot_time" "network_restart_time" "public_ip_event" "public_ip_retry_count" "soc_code" "sleeptime" "up_timeout" "down_timeout" "device_aliases" "debuglevel" "cpuload" "temperature" "send_mode" "regular_time" "regular_time_2" "regular_time_3" "interval_time" "thread_num" "timeout_retry_count" "err_device_aliases" "oui_dir" "oui_data" "client_usage" "client_usage_max" "client_usage_disturb" "client_usage_whitelist" "reset_regularly"
+	get_config "serverchan_enable" "sckey" "sctkey" "qywx_token" "tg_token" "chat_id" "pushplus_token" "serverchan_ipv4" "ipv4_interface" "ipv4_URL" "serverchan_ipv6" "ipv6_interface" "ipv6_URL" "serverchan_up" "serverchan_down" "serverchan_sheep" "serverchan_whitelist" "serverchan_blacklist" "serverchan_interface" "starttime" "endtime" "cpuload_enable" "cpuload" "temperature_enable" "temperature" "device_name" "err_enable" "network_err_event" "err_sheep_enable" "system_time_event" "autoreboot_time" "network_restart_time" "public_ip_event" "public_ip_retry_count" "soc_code" "sleeptime" "up_timeout" "down_timeout" "device_aliases" "debuglevel" "cpuload" "temperature" "send_mode" "regular_time" "regular_time_2" "regular_time_3" "interval_time" "thread_num" "timeout_retry_count" "err_device_aliases" "oui_dir" "oui_data" "client_usage" "client_usage_max" "client_usage_disturb" "client_usage_whitelist" "reset_regularly"
 	for str_version in "wrtbwmon" "iputils-arping" "curl" "iw"; do
 		eval `echo ${str_version:0:2}"_version"`=`opkg list-installed|grep -w ^${str_version}|awk '{print $3}'` 2>/dev/null
 	done
@@ -31,6 +31,7 @@ function read_config(){
 	[ ! -z "$pushplus_token" ] && [ -z "$sckey" ] && str_tab=""
 	[ ! -z "$tg_token" ] && [ -z "$sckey" ] && str_title_start="<b>" && str_title_end="</b>";
 	[ ! -z "$tg_token" ] && [ -z "$pushplus_token" ] && str_splitline="%0D%0A%0D%0A"
+	[ ! -z "$qywx_token" ] && [ -z "$pushplus_token" ] && str_title_start="<h3>" && str_title_end="</h3>" && str_splitline='<hr>' && str_linefeed='<br>' && str_tab='<li>'
 }
 
 # 初始化
@@ -43,14 +44,37 @@ function serverchan_init(){
 	fi
 	down_oui &
 	deltemp
-	
+
 	rm -f ${dir}fd1 ${dir}sheep_usage ${dir}old_sheep_usage ${dir}client_usage_aliases ${dir}old_client_usage_aliases /usr/bin/serverchan/errlog >/dev/null 2>&1
 	[ ! -f "/usr/sbin/wrtbwmon" ] && echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】未安装 wrtbwmon ，流量统计不可用" >> ${logfile}
 	[ -z "$ip_version" ] && echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】无法获取依赖项 iputils-arping 版本号，请确认插件是否正常运行" >> ${logfile}
 	[ -z "$cu_version" ] && echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】无法获取依赖项 curl 版本号，请确认插件是否正常运行" >> ${logfile}
-	[ -z "${sckey}${tg_token}${pushplus_token}" ] && echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】请填写正确的 key " >> ${logfile} && return 1
+	[ -z "${sckey}${tg_token}${pushplus_token}${qywx_token}" ] && echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】请填写正确的 key " >> ${logfile} && return 1
 	local interfacelist=`getinterfacelist` && [ -z "$interfacelist" ] && echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】无法正确获取接口信息，请确认插件是否正常运行" >> ${logfile}
 	return 0
+}
+
+# 企业微信推送
+qywx_push(){
+	qywx_am="$1"
+	title=`echo "$2"|sed 's/%20/\ /g'`
+	digest="$3"
+	content=`echo "$4"|sed 's/%25/%/g'|sed 's/%e2%84%83/℃/g'`
+	[ -z "$nowtime" ] && nowtime=`date "+%Y-%m-%d %H:%M:%S"`
+	[ -z "$digest" ] && digest="`echo "$content"|sed 's/<br>/\\\n/g'| sed 's/<hr>//g'|sed 's/<li>//g'|sed 's/<h3>/\\\n\\\n#/g'|sed 's$</h3>$$g'|sed 's/^\(\\\n\)*//g'`"
+	corpid=`echo "$qywx_am" | awk -F\; '{print $1}'`
+	touser=`echo "$qywx_am" | awk -F\; '{print $2}'`
+	agentid=` echo "$qywx_am" | awk -F\; '{print $3}'`
+	corpsecret=` echo "$qywx_am" | awk -F\; '{print $4}'`
+	msg_tpl='{"touser":"%s","msgtype":"mpnews","agentid":"%s","mpnews":{"articles":[{"title":"%s","thumb_media_id":"2W7Z57OyTLucp7vITMX66fcr-Flxd1eXQtfMhmVMuxKFTRB9pED-h8s-GUR1DdDzb","author":"ServerChan","digest":"%s","content":"%s"}]}}\n'
+	qywx_ret=$(curl -ks "https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid=${corpid}&corpsecret=${corpsecret}")
+	if [ `echo "${qywx_ret//\"/}" | sed "s/.*errcode:\([^,}]*\).*/\1/"` -ne 0 ]; then
+	echo "`date "+%Y-%m-%d %H:%M:%S"` 【微信推送】获取企业微信推送 token 失败" >> ${logfile}
+	else
+	token=`echo "${qywx_ret//\"/}" | sed "s/.*access_token:\([^,}]*\).*/\1/"`
+	fi
+	printf "$msg_tpl" "$touser" "$agentid" "$title" "$digest" "${nowtime}${content}"|curl -X POST -d@- -H "Content-Type: application/json" "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=${token}"
+	digest=''
 }
 
 # 下载设备MAC厂商信息
@@ -241,7 +265,7 @@ function get_client_usage(){
 	[ "$client_usage_disturb" -eq "0" ] && [ -f "${dir}ipAddress" ] && local MACLIST=`cat ${dir}ipAddress|awk '{print $2}'|grep -v "^$"|sort -u`
 	[ "$client_usage_disturb" -eq "1" ] && [ ! -z "$client_usage_whitelist" ] && local MACLIST=`echo "$client_usage_whitelist"`
 	[ -z "$MACLIST" ] && return
-		
+
 	if [ "$((`date +%s`-$get_client_usage_time))" -ge "60" ]; then
 		> ${dir}client_usage_aliases
 		for mac in $MACLIST; do
@@ -360,7 +384,7 @@ function serverchan_cron(){
 		re_cron
 		return
 	fi
-	
+
 	# 重置流量
 	if [ ! -z "$reset_regularly" ] && [ "$reset_regularly" -eq "1" ]; then
 		crontab -l > conf && echo -e "0 0 * * * rm /tmp/serverchan/usage.db >/dev/null 2>&1" >> conf && crontab conf && rm -f conf >/dev/null 2>&1
@@ -442,7 +466,7 @@ function get_client(){
 	done < ${dir}ipAddress
 	fi
 cat>/usr/lib/lua/luci/view/serverchan/client.htm<<EOF
-<h2><%:在线设备列表%></h2><div class="table" id="traffic"><div class="tr table-titles"><div class="th" id="thClient" style="width:17%"><%:客户端名%></div><div class="th" id="thMAC" style="width:10%"><%:MAC%></div><div class="th" id="thIP" style="width:17%"><%:IP%></div><div class="th" id="thTotal" style="width:9%"><%:总计流量%></div><div class="th" id="thFirstSeen" style="width:15%"><%:在线时间%></div></div>
+<h2><%:在线设备列表%></h2><div class="table" id="traffic"><div class="tr table-titles"><div class="th" id="thClient" style="width:17%"><%:客户端名%></div><div class="th" id="thMAC" style="width:10%"><%:MAC%></div><div class="th" id="thIP" style="width:17%"><%:IP%></div><div class="th" id="thTotal" style="width:9%"><%:总计流量%></div><div class="th" id="thFirstSeen" style="width:15%"><%: 在线时间%></div></div>
 $js_str
 </div>
 EOF
@@ -490,7 +514,7 @@ function unattended(){
 	[ -z "$err_enable" ] || [ "$err_enable" -ne "1" ] && return
 	[ ! -z "$err_sheep_enable" ] && [ "$err_sheep_enable" -eq "1" ] && [ -z "$sheep_starttime" ] && return
 	geterrdevicealiases;[ $? -eq "1" ] && return
-	
+
 	if [ ! -z "$system_time_event" ]; then
 		local interfaceuptime=`getinterfaceuptime`
 		if [ ! -z "$autoreboot_time" ] && [ `cat /proc/uptime|awk -F. '{run_hour=$1/3600;printf("%d",run_hour)}'` -ge "$autoreboot_time" ] && [ "$system_time_event" -eq "1" ]; then
@@ -559,7 +583,7 @@ function rand_geturl(){
 					elif [ "$network_err_event" -eq "2" ] ;then
 						[ "$retry_count" -lt "3" ] && echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！！】正在尝试重启网络，当前第 $retry_count 次 " >> ${logfile} && ifup wan >/dev/null 2>&1
 						[ "$retry_count" -eq "3" ] && echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！！】已经重启网络2次，修复失败，请主人自行修复哦 " >> ${logfile}
-					elif [ "$network_err_event" -eq "3" ] ;then				
+					elif [ "$network_err_event" -eq "3" ] ;then
 						if [ "$retry_count" -eq "1" ] ;then
 							echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！！】正在尝试修复网络，当前第 1 次，重启网络服务中 " >> ${logfile} && network_restart
 						elif [ "$retry_count" -eq "2" ] ;then
@@ -638,7 +662,7 @@ function ip_changes(){
 		elif [ ! -z "$serverchan_ipv4" ] && [ "$serverchan_ipv4" -ne "0" ] && [ -z "$IPv4" ]; then
 			echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】获取 IPv4 地址失败" >> ${logfile}
 		fi
-		
+
 		if [ ! -z "$serverchan_ipv6" ] && [ "$serverchan_ipv6" -ne "0" ] && [ ! -z "$IPv6" ] && ( ! echo "$IPv6"|grep -w -q ${last_IPv6} ); then
 			echo "`date "+%Y-%m-%d %H:%M:%S"` ${disturb_text}当前IPv6：${IPv6}" >> ${logfile}
 			echo IPv4 $IPv4 > ${dir}ip && echo -e IPv6 $IPv6 >> ${dir}ip
@@ -648,7 +672,7 @@ function ip_changes(){
 		elif [ ! -z "$serverchan_ipv6" ] && [ "$serverchan_ipv6" -ne "0" ] && [ -z "$IPv6" ]; then
 			echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！！】获取 IPv6 地址失败" >> ${logfile}
 		fi
-		
+
 	else
 		echo "`date "+%Y-%m-%d %H:%M:%S"` ${disturb_text}路由器已经重启!" >> ${logfile}
 		[ ! -z "$serverchan_ipv4" ] && [ "$serverchan_ipv4" -ne "0" ] && echo "`date "+%Y-%m-%d %H:%M:%S"`  当前IP: ${IPv4}" >> ${logfile}
@@ -659,7 +683,7 @@ function ip_changes(){
 		[ ! -z "$serverchan_ipv4" ] && [ "$serverchan_ipv4" -ne "0" ] && content="${content}${str_linefeed}${str_tab}当前IP：${IPv4}"
 		[ ! -z "$serverchan_ipv6" ] && [ "$serverchan_ipv6" -ne "0" ] && content="${content}${str_linefeed}${str_tab}当前IPv6：${IPv6}"
 	fi
-	
+
 	if [ ! -z "$content" ] ;then
 		[ -z "$ddns_enabled" ] && ddns_enabled=$(uci show ddns|grep "enabled"|grep "1")
 		[ -z "$ddns_enabled" ] && ddns_logrow=0 || ddns_logrow=$(echo "$ddns_enabled"|wc -l)
@@ -692,7 +716,7 @@ function up(){
 			[ ! -z "$serverchan_up" ] && [ "$serverchan_up" -ne "1" ] && LockFile unlock && return
 			[ ! -z "$ip_blackwhite" ] && [ "$ip_blackwhite" -ne "0" ] && LockFile unlock && return
 			[ -f "${dir}title" ] && local title=`cat ${dir}title`
-			[ -f "${dir}content" ] && local content=`cat ${dir}content`	
+			[ -f "${dir}content" ] && local content=`cat ${dir}content`
 			if [ -z "$title" ]; then
 				local title="$ip_name 连接了你的路由器"
 				local content="${str_splitline}${str_title_start} 新设备连接${str_title_end}${str_linefeed}${str_tab}客户端名：${str_space}${str_space}${str_space}${str_space}${str_space}${ip_name}${str_linefeed}${str_tab}客户端IP： ${str_space}${str_space}${str_space}${str_space}${1}${str_linefeed}${str_tab}客户端MAC：${str_space}${str_space}${str_space}${str_space}${ip_mac}${str_linefeed}${str_tab}网络接口：${str_space}${str_space}${str_space}${str_space}${str_space}${ip_interface}"
@@ -702,7 +726,7 @@ function up(){
 			else
 				local title="设备状态变化"
 				local content="${str_splitline}${str_title_start} 新设备连接${str_title_end}${str_linefeed}${str_tab}客户端名：${str_space}${str_space}${str_space}${str_space}${str_space}${ip_name}${str_linefeed}${str_tab}客户端IP： ${str_space}${str_space}${str_space}${str_space}${1}${str_linefeed}${str_tab}客户端MAC：${str_space}${str_space}${str_space}${str_space}${ip_mac}${str_linefeed}${str_tab}网络接口：${str_space}${str_space}${str_space}${str_space}${str_space}${ip_interface}"
-			fi				
+			fi
 			echo "`date "+%Y-%m-%d %H:%M:%S"` ${disturb_text}新设备 ${ip_name} ${1} 连接了">> ${logfile}
 			#[ ! -z "$serverchan_blacklist" ] && local title="你偷偷关注的设备上线了"
 			[ ! -z "$title" ] && echo "$title" >${dir}title
@@ -776,14 +800,14 @@ function current_device(){
 		local ip_total=`usage get ${ip_mac}`
 		local ip_name=`getname ${ip} ${ip_mac}`
 		local ip_name=`cut_str $ip_name 15`
-		if [ "${#ip}" -lt "15" ]; then 
+		if [ "${#ip}" -lt "15" ]; then
 			local n=`expr 15 - ${#ip}`
 			for i in `seq 1 $n`; do
 				local ip="${ip}${str_space}"
 			done
 			unset i n
 		fi
-		if [ ! -z "$ip_total" ]; then	
+		if [ ! -z "$ip_total" ]; then
 			local n=`expr 11 - ${#ip_total}`
 			for i in `seq 1 $n`; do
 				local ip_total="${ip_total}${str_space}"
@@ -800,18 +824,18 @@ function cpu_load(){
 		[ -z "$temperature_time" ] && temperature_time=`date +%s`
 		local cpu_wendu=`soc_temp`;
 		[ -z "$cpu_wendu" ] && echo "`date "+%Y-%m-%d %H:%M:%S"`  【！！！】无法读取设备温度，请检查命令" >> ${logfile}
-		
+
 		if [ "$cpu_wendu" -gt "$temperature" ]; then
 			echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！警报！！】 CPU 温度过高: ${cpu_wendu}" >> ${logfile}
 		else
 			temperature_time=`date +%s`
 		fi
-		
+
 		if [ "$((`date +%s`-$temperature_time))" -ge "300" ] && [ -z "$temperaturecd_time" ]; then
 			title="CPU 温度过高！"
 			temperaturecd_time=`date +%s`
 			echo "`date "+%Y-%m-%d %H:%M:%S"` ${disturb_text} CPU 温 度过高: ${cpu_wendu}" >> ${logfile}
-			content="${content}${str_splitline}${str_title_start} CPU 温度过高${str_title_end}${str_linefeed}${str_tab}CPU 温度已连续五分钟超过预设${str_linefeed}${str_tab}接下来一小时不再提示${str_linefeed}${str_tab}当前温度：${cpu_wendu}"
+			content="${content}${str_splitline}${str_title_start} CPU 温度过高${str_title_end}${str_linefeed}${str_tab}CPU 温度已连续五分钟超过预设${str_linefeed}${str_tab}接下来一小 时不再提示${str_linefeed}${str_tab}当前温度：${cpu_wendu}"
 		elif [ ! -z "$temperaturecd_time" ] && [ "$((`date +%s`-$temperaturecd_time))" -ge "3300" ] ;then
 			unset temperaturecd_time
 		fi
@@ -821,14 +845,14 @@ function cpu_load(){
 		[ -z "$cpuload_time" ] && cpuload_time=`date +%s`
 		local cpu_fuzai=`cat /proc/loadavg|awk '{print $1}'` 2>/dev/null
 		[ -z "$cpu_fuzai" ] && echo "`date "+%Y-%m-%d %H:%M:%S"`  【！！！】无法读取设备负载，请检查命令" >> ${logfile}
-		
+
 		if [ `expr $cpu_fuzai \> $cpuload` -eq "1" ]; then
 			echo "`date "+%Y-%m-%d %H:%M:%S"` 【！！警报！！】 CPU 负载过高: ${cpu_fuzai}" >> ${logfile}
 			cputop log
 		else
 			cpuload_time=`date +%s`
 		fi
-		
+
 		if [ "$((`date +%s`-$cpuload_time))" -ge "300" ] && [ -z "$cpucd_time" ]; then
 			unset getlogtop
 			if [ ! -z "$title" ] && ( echo "$title"|grep -q "过高" ); then
@@ -838,7 +862,7 @@ function cpu_load(){
 			fi
 			cpucd_time=`date +%s`
 			echo "`date "+%Y-%m-%d %H:%M:%S"` ${disturb_text} CPU 负 载过高: ${cpu_fuzai}" >> ${logfile}
-			content="${content}${str_splitline}${str_title_start} CPU 负载过高${str_title_end}${str_linefeed}${str_tab}CPU 负载已连续五分钟超过预设${str_linefeed}${str_tab}接下来一小时不再提示${str_linefeed}${str_tab}当前负载：${cpu_fuzai}"
+			content="${content}${str_splitline}${str_title_start} CPU 负载过高${str_title_end}${str_linefeed}${str_tab}CPU 负载已连续五分钟超过预设${str_linefeed}${str_tab}接下来一小 时不再提示${str_linefeed}${str_tab}当前负载：${cpu_fuzai}"
 			cputop
 		elif [ ! -z "$cpucd_time" ] && [ "$((`date +%s`-$cpucd_time))" -ge "3300" ] ;then
 			unset cpucd_time
@@ -885,7 +909,7 @@ function send(){
 		local send_content="${send_content}${str_linefeed}${str_tab}${systemstatustime}"
 	fi
 
-	[ ! -z "$router_temp" ] && [ "$router_temp" -eq "1" ] && local cputemp=`soc_temp` && local send_content="${send_content}${str_splitline}${str_title_start} 设备温度${str_title_end}${str_linefeed}${str_tab}CPU：${cputemp}%e2%84%83"	#%e2%84%83="℃"
+	[ ! -z "$router_temp" ] && [ "$router_temp" -eq "1" ] && local cputemp=`soc_temp` && local send_content="${send_content}${str_splitline}${str_title_start} 设备温度${str_title_end}${str_linefeed}${str_tab}CPU：${cputemp}%e2%84%83"	  #%e2%84%83="℃"
 
 	if [ ! -z "$router_wan" ] && [ "$router_wan" -eq "1" ]; then
 		local send_wanIP=`getip wanipv4`;local send_hostIP=`getip hostipv4`
@@ -920,11 +944,12 @@ function send(){
 	fi
 	[ ! -z "$device_name" ] && local send_title="【$device_name】${send_title}"
 	local send_title=`echo "$send_title"|sed $'s/\ /%20/g'|sed $'s/\"/%22/g'|sed $'s/\#/%23/g'|sed $'s/\&/%26/g'|sed $'s/\,/%2C/g'|sed $'s/\//%2F/g'|sed $'s/\:/%3A/g'|sed $'s/\;/%3B/g'|sed $'s/\=/%3D/g'|sed $'s/\@/%40/g'`
-	[ -z "$send_content" ] && local send_content="${str_splitline}${str_title_start} 我遇到了一个难题${str_title_end}${str_linefeed}${str_tab}定时发送选项错误，你没有选择需要发送的项目，该怎么办呢${str_splitline}"
+	[ -z "$send_content" ] && local send_content="${str_splitline}${str_title_start} 我遇到了一个难题${str_title_end}${str_linefeed}${str_tab}定时发送选项错误，你没有选择需要发送的项目，该怎 么办呢${str_splitline}"
 	local nowtime=`date "+%Y-%m-%d %H:%M:%S"`
 	[ "$send_disturb" -eq "0" ] && [ ! -z "$sckey" ] && curl -s "${sckey_url}?text=${send_title}" -d "&desp=${nowtime}${str_linefeed}${send_content}" >/dev/null 2>&1
 	[ "$send_disturb" -eq "0" ] && [ ! -z "$tg_token" ] && curl -s "https://api.telegram.org/bot${tg_token}/sendMessage" -d "chat_id=${chat_id}&text=${str_title_start}${send_title}${str_title_end}${str_linefeed}${nowtime}${send_content}&parse_mode=HTML" >/dev/null 2>&1
 	[ "$send_disturb" -eq "0" ] && [ ! -z "$pushplus_token" ] && curl -s "http://pushplus.plus/send?token=${pushplus_token}" -d "&title=${send_title}&content=${send_content}&template=markdown" >/dev/null 2>&1
+	[ "$send_disturb" -eq "0" ] && [ ! -z "$qywx_token" ] && qywx_push "$qywx_token" "$send_title" "$digest" "$send_content" >/dev/null 2>&1
 	deltemp
 	echo "`date "+%Y-%m-%d %H:%M:%S"` ${disturb_text}定时推送任务完成" >> ${logfile}
 }
@@ -969,7 +994,7 @@ while [ "$serverchan_enable" -eq "1" ]; do
 		rand_geturl
 		ip_changes
 	fi
-	
+
 	# 设备列表
 	if [ ! -f "${dir}send_enable.lock" ]; then
 		[ ! -z "$title" ] && echo "$title" > ${dir}title
@@ -978,19 +1003,19 @@ while [ "$serverchan_enable" -eq "1" ]; do
 		[ -f "${dir}title" ] && title=`cat ${dir}title` && rm -f ${dir}title >/dev/null 2>&1
 		[ -f "${dir}content" ] && content=`cat ${dir}content` && rm -f ${dir}content >/dev/null 2>&1
 	fi
-	
+
 	# 离线缓存区推送
 	[ ! -f "${dir}send_enable.lock" ] && down_send
-	
+
 	# 当前设备列表
 	[ ! -z "$content" ] && [ ! -f "${dir}send_enable.lock" ] && current_device
-	
+
 	# 无人值守任务
 	[ ! -f "${dir}send_enable.lock" ] && unattended
 
 	# CPU 检测
 	[ ! -f "${dir}send_enable.lock" ] && cpu_load
-	
+
 	# 异常流量检测
 	[ ! -f "${dir}send_enable.lock" ] && get_client_usage
 
@@ -1001,6 +1026,7 @@ while [ "$serverchan_enable" -eq "1" ]; do
 		[ "$disturb" -eq "0" ] && [ ! -z "$sckey" ] && curl -s "${sckey_url}?text=${title}" -d "desp=${nowtime}${str_linefeed}${content}" >/dev/null 2>&1
 		[ "$disturb" -eq "0" ] && [ ! -z "$tg_token" ] && curl -s "https://api.telegram.org/bot${tg_token}/sendMessage" -d "chat_id=${chat_id}&text=${str_title_start}${title}${str_title_end}${str_linefeed}${nowtime}${content}&parse_mode=HTML" >/dev/null 2>&1
 		[ "$disturb" -eq "0" ] && [ ! -z "$pushplus_token" ] && curl -s "http://pushplus.plus/send?token=${pushplus_token}" -d "&title=${title}&content=${content}&template=markdown" >/dev/null 2>&1
+		[ "$disturb" -eq "0" ] && [ ! -z "$qywx_token" ] &&  qywx_push "$qywx_token" "$title" "$digest" "$content" >/dev/null 2>&1
 	fi
 	
 	while [ -f "${dir}send_enable.lock" ]; do
@@ -1008,4 +1034,3 @@ while [ "$serverchan_enable" -eq "1" ]; do
 	done
 	sleep $sleeptime
 done
-


### PR DESCRIPTION
### 背景

> [sc.ftqq.com 分期下线通知和常见问题解答](https://mp.weixin.qq.com/s/KGQC1v5rsG_JKVRtN2DY4w)

原微信推送计划下线旧版入口，思考直接迁移到企业微信推送

### 推送方法

企业微信推送的调用方式与原来的推送方式存在一些差异：

1. 需要先调用一个接口获取 access_token
2. 仅支持 post 方法调用推送接口
3. 参数必须 json 格式的 payload 上传，不需要 urlencode

因此单独新增一个函数来处理企业微信推送细节 `qywx_push()`，这样可以保持与原有的推送调用代码风格保持一致

### 消息类型

关于推送消息的类型，选择了 **mpnews** 格式的消息：

1. 支持设置卡片横幅图片（目前是预设，不支持定义，后续可调整）
2. 支持显示摘要，不需要点开消息卡片即可看到摘要内容
3. 实际推送内容通过 html 语法进行排版，因 mpnews 不支持 markdown

### luci 界面

新增**企业微信凭证**参数栏：

![image](https://user-images.githubusercontent.com/2578976/122789976-701c1180-d2ea-11eb-8ef4-59c845e4d6e3.png)

合并企业微信推送需要多个信息，后续在脚本中拆分获取，并且在页面上进行提示：

1. 因为使用了 html 格式，会导致原来的微信推送排版异常（应该是可以修复，毕竟 markdown 支持 html 语法）
2. 凭证的格式以及获取方式，提供了企业微信对应的链接说明

### 推送效果

已在本地编译并测试正常，效果如下：

![image](https://user-images.githubusercontent.com/2578976/122790885-529b7780-d2eb-11eb-8866-dce8cdf3be33.png)

![image](https://user-images.githubusercontent.com/2578976/122791067-778fea80-d2eb-11eb-87be-498f973aac71.png)


### 其他

部分空行及末尾空格被吃掉，不影响代码运行，但会导致额外的 diff 内容，见谅


Closed: #143 

