### PR TITLE
fix: 修复因 mediaid 无法跨企业共享导致的推送失败问题

### DIFF
--- a/luasrc/model/cbi/serverchan/setting.lua
+++ b/luasrc/model/cbi/serverchan/setting.lua
@@ -30,7 +30,7 @@ a.rmempty = true
 a=s:taboption("basic", Value,"sckey",translate('微信推送/新旧共用'), translate("").."旧版调用代码<a href='http://sc.ftqq.com' target='_blank'>点击这里</a><br>新版代码获取<a href='https://sct.ftqq.com/' target='_blank'>点击这里</a><br>")
 a.rmempty = true
 
-a=s:taboption("basic", Value,"qywx_token",translate('企业微信凭证'), translate("").."格式必须为：corpid;userid;agentid;corpsecret，获取说明<a href='https://work.weixin.qq.com/api/doc/10013' target='_blank'>点击这里</a><br>注意：使用企业微信推送会导致其他推送的内容排版错乱")
+a=s:taboption("basic", Value,"qywx_token",translate('企业微信凭证'), translate("").."格式必须为：corpid;userid;agentid;corpsecret;mediaid，获取说明<a href='https://work.weixin.qq.com/api/doc/10013' target='_blank'>点击这里</a><br>图片对应 mediaid 是必须的，且因无法夸企业共享需要自行上传到素材库并获取 mediaid<br>注意：使用企业微信推送会导致其他推送的内容排版错乱")
 a.rmempty = true
 
 a=s:taboption("basic",Value,"pushplus_token",translate('pushplus_token'),translate("").."获取pushplus_token <a href='http://www.pushplus.plus/' target='_blank'>点击这里</a><br>")

--- a/root/usr/bin/serverchan/serverchan
+++ b/root/usr/bin/serverchan/serverchan
@@ -66,14 +66,15 @@ qywx_push(){
 	touser=`echo "$qywx_am" | awk -F\; '{print $2}'`
 	agentid=` echo "$qywx_am" | awk -F\; '{print $3}'`
 	corpsecret=` echo "$qywx_am" | awk -F\; '{print $4}'`
-	msg_tpl='{"touser":"%s","msgtype":"mpnews","agentid":"%s","mpnews":{"articles":[{"title":"%s","thumb_media_id":"2W7Z57OyTLucp7vITMX66fcr-Flxd1eXQtfMhmVMuxKFTRB9pED-h8s-GUR1DdDzb","author":"ServerChan","digest":"%s","content":"%s"}]}}\n'
+    mediaid=` echo "$qywx_am" | awk -F\; '{print $5}'`
+	msg_tpl='{"touser":"%s","msgtype":"mpnews","agentid":"%s","mpnews":{"articles":[{"title":"%s","thumb_media_id":"%s","author":"ServerChan","digest":"%s","content":"%s"}]}}\n'
 	qywx_ret=$(curl -ks "https://qyapi.weixin.qq.com/cgi-bin/gettoken?corpid=${corpid}&corpsecret=${corpsecret}")
 	if [ `echo "${qywx_ret//\"/}" | sed "s/.*errcode:\([^,}]*\).*/\1/"` -ne 0 ]; then
 	echo "`date "+%Y-%m-%d %H:%M:%S"` 【微信推送】获取企业微信推送 token 失败" >> ${logfile}
 	else
 	token=`echo "${qywx_ret//\"/}" | sed "s/.*access_token:\([^,}]*\).*/\1/"`
 	fi
-	printf "$msg_tpl" "$touser" "$agentid" "$title" "$digest" "${nowtime}${content}"|curl -X POST -d@- -H "Content-Type: application/json" "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=${token}"
+	printf "$msg_tpl" "$touser" "$agentid" "$title" "$mediaid" "$digest" "${nowtime}${content}"|curl -X POST -d@- -H "Content-Type: application/json" "https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=${token}"
 	digest=''
 }
 


### PR DESCRIPTION
提供对应的 mediaid 设置让用户自行设置

详细背景见下方关联的 issue，目前企业微信的设置确实比较麻烦，且因为 media 无法跨企业共享，经讨论确定直接暴露对应设置参数。

closed: #145 